### PR TITLE
220117 2번, 3번 문제

### DIFF
--- a/Wooyongjeong/220117/02 [BOJ] 15685 드래곤 커브.py
+++ b/Wooyongjeong/220117/02 [BOJ] 15685 드래곤 커브.py
@@ -1,0 +1,52 @@
+def get_next_generation_dirs(dirs):
+    # dirs를 회전시켜 다음 세대의 dirs를 반환
+    rotated_dirs = []
+    for d in dirs:
+        rotated_dirs.append((d + 1) % 4)
+    return rotated_dirs
+
+
+def make_curve_dirs(d, g):
+    # g세대까지 방향 d부터 시작하는 dirs 반환
+    dirs = [d]  # 0세대
+    for _ in range(g):  # 1세대 ~ g세대
+        dirs += get_next_generation_dirs(dirs[::-1])
+    return dirs
+
+
+def solution(curves):
+    # 0 <= x <= 100, 0 <= y <= 100
+    board = [[0 for _ in range(MAX + 1)] for _ in range(MAX + 1)]
+
+    # 각 curve마다 curve_dirs를 이용하여 board에 표시
+    for curve in curves:
+        # 이번 문제에서 입력으로 주어지는 x, y는 x가 가로, y가 세로
+        # 평소 2차원 배열 풀던 행열과 다르게 봐야 함
+        y, x, d, g = curve
+        board[x][y] = 1
+        curve_dirs = make_curve_dirs(d, g)
+
+        for curve_dir in curve_dirs:
+            x += dx[curve_dir]
+            y += dy[curve_dir]
+            # 문제 조건: board를 벗어나는 드래곤 커브는 없음
+            board[x][y] = 1
+
+    answer = 0
+    for i in range(MAX):
+        for j in range(MAX):
+            if board[i][j] != 0 and board[i + 1][j] != 0 and \
+                    board[i][j + 1] != 0 and board[i + 1][j + 1] != 0:
+                answer += 1
+    return answer
+
+
+if __name__ == '__main__':
+    MAX = 100
+    N = int(input())
+    # (시작 x좌표) x, (시작 y좌표) y, (시작 방향) d, (세대) g
+    dragon_curves = [list(map(int, input().split())) for _ in range(N)]
+
+    dx = [0, -1, 0, 1]  # 0 →, 1 ↑, 2 ←, 3 ↓
+    dy = [1, 0, -1, 0]
+    print(solution(dragon_curves))

--- a/Wooyongjeong/220117/03 [PGS] 60057 문자열 압축.py
+++ b/Wooyongjeong/220117/03 [PGS] 60057 문자열 압축.py
@@ -1,0 +1,42 @@
+def solution(s):
+    answer = len(s)
+
+    # step은 문자열 자를 단위
+    # s 길이의 절반보다 큰 단위부터는 볼 필요 없음
+    for step in range(1, len(s) // 2 + 1):
+        compressed = ""  # 이번 step으로 압축했을 때 결과
+        prev = s[:step]  # 우선 step개만큼 자름
+        count = 1  # prev가 반복되는 개수
+        for i in range(step, len(s), step):
+            # 이제 step번째 인덱스(단위만큼 자른 문자열의 다음 글자)부터 step개씩 자르면서
+            # 문자열 압축
+            now = s[i: i + step]  # step개만큼 자름
+            if now == prev:
+                # 자른 게 prev와 같다면, count 1 증가
+                count += 1
+                continue
+            # 자른 게 prev와 다르다면, compressed에 {count}{prev}를 붙임
+            # 이 때, count가 1이라면 count는 생략
+            # 이후 prev에 now를 저장하고 count를 1로 초기화(다시 시작)
+            compressed += f"{count}{prev}" if count > 1 else prev
+            prev = now
+            count = 1
+        # 마지막으로 남아 있는 count와 prev를 compressed에 추가
+        compressed += f"{count}{prev}" if count > 1 else prev
+        # answer 갱신
+        answer = min(answer, len(compressed))
+
+    return answer
+
+
+if __name__ == '__main__':
+    ss = [
+        "aabbaccc",  # 7
+        "ababcdcdababcdcd",  # 9
+        "abcabcdede",  # 8
+        "abcabcabcabcdededededede",  # 14
+        "xababcdcdababcdcd"  # 17
+    ]
+
+    for s in ss:
+        print("s =", s + ", result =", solution(s))


### PR DESCRIPTION
## 02 [BOJ] 15685 드래곤 커브
### 문제 접근
* 각 드래곤 커브마다 방향 d부터 시작하여 g세대까지 x, y가 이동하는 방향을 계산하여 시뮬레이션
    * g가 최대 10으로 10세대일 때 이동하는 방향의 갯수는 2^10개
    * N도 최대 20으로 작고, 격자 x, y 좌표 역시 최대 100으로 작으므로 `브루트 포스` 가능

### 문제 풀이 방향
1. 각 드래곤 커브(이하 `curve`)마다 x, y, d, g가 주어짐.
2. `시작 좌표 (x, y)`, `시작 방향 d`와 curve의 `세대 g`
3. 이를 토대로 문제 조건의 `0세대`부터 `g세대`까지 이동 방향 리스트 `curve_dirs`를 구함
    * 0: x좌표가 증가하는 방향 (→)
    * 1: y좌표가 감소하는 방향 (↑)
    * 2: x좌표가 감소하는 방향 (←)
    * 3: y좌표가 증가하는 방향 (↓)
4. curve_dirs에 따라 격자에 표시
5. 크기가 1x1인 정사각형의 네 꼭짓점이 모두 드래곤 커브의 일부인 것의 개수를 계산하여 return

## 03 [PGS] 60057 문자열 압축
### 문제 접근
- 그냥 문제가 시키는 대로 구현하는 문제
- `문자열 슬라이싱`을 잘 이용하면 됨

### 알고리즘
1. step을 증가시키며 문자열 압축
2. 매 step마다 answer 갱신
