### PR TITLE
220124) 03 [PGS] 72412 순위 검색, 추가 문제 [PGS] 60060 가사 검색

### DIFF
--- a/Wooyongjeong/220124/03 [PGS] 72412 순위 검색.py
+++ b/Wooyongjeong/220124/03 [PGS] 72412 순위 검색.py
@@ -1,0 +1,49 @@
+import collections
+import itertools
+import bisect
+
+
+def make_info_dict(info):
+    info_dict = collections.defaultdict(list)
+    for i in info:
+        i = i.split()
+        data, score = i[:-1], int(i[-1])
+        info_dict[''.join(data)].append(score)
+        for count in range(1, 5):
+            for indexes in itertools.combinations(range(4), count):
+                copied_data = data[:]
+                for index in indexes:
+                    copied_data[index] = '-'
+                info_dict[''.join(copied_data)].append(score)
+
+    for value in info_dict.values():
+        value.sort()
+
+    return info_dict
+
+
+def solution(info, query):
+    info_dict = make_info_dict(info)
+    answer = []
+    for q in query:
+        q = [x for x in q.split() if x != 'and']
+        key, score = ''.join(q[:-1]), int(q[-1])
+        count = len(info_dict[key]) - bisect.bisect_left(info_dict[key], score)
+        answer.append(count)
+    return answer
+
+
+if __name__ == '__main__':
+    info = ["java backend junior pizza 150",
+            "python frontend senior chicken 210",
+            "python frontend senior chicken 150",
+            "cpp backend senior pizza 260",
+            "java backend junior chicken 80",
+            "python backend senior chicken 50"]
+    query = ["java and backend and junior and pizza 100",
+             "python and frontend and senior and chicken 200",
+             "cpp and - and senior and pizza 250",
+             "- and backend and senior and - 150",
+             "- and - and - and chicken 100",
+             "- and - and - and - 150"]
+    print(solution(info, query))  # [1, 1, 1, 1, 2, 4]

--- a/Wooyongjeong/220124/추가문제 [PGS] 60060 가사 검색.py
+++ b/Wooyongjeong/220124/추가문제 [PGS] 60060 가사 검색.py
@@ -1,0 +1,48 @@
+import bisect
+
+
+def count_by_range(iterable, left_value, right_value):
+    left_index = bisect.bisect_left(iterable, left_value)
+    right_index = bisect.bisect_right(iterable, right_value)
+    return right_index - left_index
+
+
+def make_notes(words):
+    SIZE = 100000
+
+    word_note = [[] for _ in range(SIZE + 1)]
+    reversed_word_note = [[] for _ in range(SIZE + 1)]
+
+    for word in words:
+        word_note[len(word)].append(word)
+        reversed_word_note[len(word)].append(word[::-1])
+
+    for length in range(2, SIZE + 1):
+        word_note[length].sort()
+        reversed_word_note[length].sort()
+
+    return word_note, reversed_word_note
+
+
+def solution(words, queries):
+    answer = []
+    word_note, reversed_word_note = make_notes(words)
+
+    for query in queries:
+        if not query.startswith('?'):
+            count = count_by_range(word_note[len(query)],
+                                   query.replace('?', 'a'),
+                                   query.replace('?', 'z'))
+        else:
+            count = count_by_range(reversed_word_note[len(query)],
+                                   query[::-1].replace('?', 'a'),
+                                   query[::-1].replace('?', 'z'))
+        answer.append(count)
+
+    return answer
+
+
+if __name__ == '__main__':
+    words = ["frodo", "front", "frost", "frozen", "frame", "kakao"]
+    query = ["fro??", "????o", "fr???", "fro???", "pro?"]
+    print(solution(words, query))  # [3, 2, 4, 1, 0]


### PR DESCRIPTION
## 03 [PGS] 72412 순위 검색
### 문제 접근 및 풀이
* 구현 (자료 구조), 이진 탐색
* info는 `개발언어 직군 경력 소울푸드 점수` 형식
    * 점수를 제외한 정보 4가지를 아무것도 마스킹하지 않은 것부터 모두 마스킹(-)한것까지
        * 예) `javabackendjuniorchicken`, `-backendjuniorchicken`, `java-juniorchicken`, … , `----`
    * 총 16개(2^4)를 key로 하고, 점수를 value로 하는 dict에 저장
* 즉, 각 info로 가능한 query의 모든 경우의 수를 저장
    * info 크기 최대 50000 * 각 경우의 수 16 = 800,000으로 충분함
* query는 `개발언어 and 직군 and 경력 and 소울푸드 점수` 형식
    * and을 모두 지우고, `''.join()`을 이용해 하나의 문자열(위 dict의 key 형식)로 붙임
* bisect 모듈을 이용해 query의 점수 이상인 개수를 계산하여 정답 배열에 append

## 추가문제 [PGS] 60060 가사 검색
### 문제 접근
* words 리스트의 최대 길이는 100,000이고, queries 리스트의 최대 길이 역시 100,000으로 브루트포스로 풀었을 시 효율성 테스트를 통과할 수 없음
* 즉 `O(logn)`의 시간 복잡도를 갖는 알고리즘으로 풀어야 함.
* 이런 문자열 관련 문제를 풀 때 유용한 `트라이`를 이용할 수도 있지만, 여기서는 `이진 탐색`을 이용하여 O(logn)의 시간 복잡도로 해결
### 알고리즘
1. words 리스트의 단어들을 이용해 `word_note`, `reversed_word_note` 리스트를 만듦
    * 각 리스트는 단어의 길이를 인덱스로 함
    ```python
    word_note = [[] for _ in range(100001)]
    reversed_word_note = [[] for _ in range(100001)]
    
    for word in words:
        word_note[len(word)].append(word)
        reversed_word_note[len(word)].append(word[::-1])
    ```
2. word_note와 reversed_word_note 내부의 리스트들을 정렬함
    * `이진 탐색`을 하려면 리스트가 정렬되어 있어야 함
    ```python
    for i in range(2, 100001):
        word_note[i].sort()
        reversed_note[i].sort()
    ```
3. 이후 queries의 각 query별로,
    1. 와일드카드 `?`가 query의 앞에 있을 경우 (예. ????o)
        * query를 뒤집어(`query[::-1]`) `reversed_word_note[len(query)]`에서 이진 탐색을 이용해 정답을 구함
    2. 와일드카드 `?`가 query의 뒤에 있을 경우 (예. fr???)
        * query를 `word_note[len(query)]`에서 이진 탐색을 이용해 정답을 구함