### PR TITLE
220214) 04 [PGS] 72414 광고 삽입

### DIFF
--- a/Wooyongjeong/220214/04 [PGS] 72414 광고 삽입.py
+++ b/Wooyongjeong/220214/04 [PGS] 72414 광고 삽입.py
@@ -1,0 +1,67 @@
+"""
+1. hh:mm:ss -> 초로 변환하여 생각
+2. 동영상 재생시간은 최대 99:59:59이므로 최대 100*60*60초 = 360000초까지임
+3. ad[360000] 배열을 0으로 초기화
+    - ad[i] = n : i초에 시청자 수가 n명
+4. logs로부터 ad 배열을 구하고, 누적합을 구함
+5. 누적합을 이용하여 ad배열을 adv_time씩 확인해가며 최대 시청자 수(=최대 누적 재생시간)를 구함
+"""
+
+
+def hhmmss_to_second(hhmmss):
+    hh, mm, ss = hhmmss.split(":")
+    return int(hh) * 3600 + int(mm) * 60 + int(ss)
+
+
+def second_to_hhmmss(second):
+    hhmmss = f"{str(second // 3600).zfill(2)}:"
+    second %= 3600
+    hhmmss += f"{str(second // 60).zfill(2)}:"
+    second %= 60
+    hhmmss += str(second).zfill(2)
+    return hhmmss
+
+
+def solution(play_time, adv_time, logs):
+    play_time = hhmmss_to_second(play_time)
+    adv_time = hhmmss_to_second(adv_time)
+    ad = [0] * (SIZE + 1)
+    for log in logs:
+        start, end = map(hhmmss_to_second, log.split("-"))
+        # 시청 시작 초 start에는 시청자수 +1
+        ad[start] += 1
+        # 시청 종료 초 end에는 시청자수 -1
+        ad[end] -= 1
+    for i in range(1, SIZE + 1):
+        # 위의 start, end 체크를 바탕으로 모든 구간에 시청자수를 기록
+        # start ~ end - 1까지는 1이 되고, end초에는 0이 될거임
+        ad[i] += ad[i - 1]
+    for i in range(1, SIZE + 1):
+        # 기록된 시청자 수 ad배열을 기반으로 누적합을 구함
+        ad[i] += ad[i - 1]
+
+    max_time = ad[adv_time - 1]
+    answer = 0
+    for i in range(play_time - adv_time + 1):
+        # 누적 합으로 광고 재생 시간 동안의 누적 시청자 수를 구해서 비교
+        tmp = ad[i + adv_time] - ad[i]
+        if tmp > max_time:
+            max_time = tmp
+            answer = i + 1
+
+    return second_to_hhmmss(answer)
+
+
+if __name__ == '__main__':
+    SIZE = 100 * 60 * 60
+    play_times = ["02:03:55", "99:59:59", "50:00:00"]
+    adv_times = ["00:14:15", "25:00:00", "50:00:00"]
+    logs_list = [
+        ["01:20:15-01:45:14", "00:40:31-01:00:00", "00:25:50-00:48:29",
+         "01:30:59-01:53:29", "01:37:44-02:02:30"],
+        ["69:59:59-89:59:59", "01:00:00-21:00:00", "79:59:59-99:59:59",
+         "11:00:00-31:00:00"],
+        ["15:36:51-38:21:49", "10:14:18-15:36:51", "38:21:49-42:51:45"]
+    ]
+    for play_time, adv_time, logs in zip(play_times, adv_times, logs_list):
+        print(solution(play_time, adv_time, logs))


### PR DESCRIPTION
## 문제 접근

- `hh:mm:ss` 형식의 입력 -> `초` 단위로 변환하여 전체 시청 시간을 초 단위로 나누어 해결
- 재생시간이 최대 99:59:59로, 100시간. 즉 `360,000` (100 * 60 * 60) 사이즈의 배열에 입력으로 주어진 시청자들의 시청 시간 매 초마다 시청자 수 기록
- 광고 재생 시간인 `adv_time`만큼 `0초` ~ `(play_time - adv_time - 1)초`의 거리만큼 매 초마다 광고를 재생해보며 누적 재생시간(=`누적 시청자 수`)를 계산하면 시간 초과
- 배열에서 연속된 특정 구간의 합을 빠르게 구할 수 있는 아이디어인 `누적 합`을 이용하여 해결

## 알고리즘
1. 입력으로 주어진 `hh:mm:ss` 형식의 문자열을 초 단위의 정수로 모두 변경
2. 크기 360,000의 배열 `ad` 선언. 0으로 초기화
3. 시청자들의 시청 시간 기록 `logs`에서 각 log의 구간에 시청자 수 + 1
4. ad배열에서 1초부터 360,000초까지, 이전 시간의 값을 현재 시간의 값에 더해 `누적합` 배열 만듦
5. `최대 시청자 수`를 0초에 광고를 틀었을 때의 시청자 수로 초기화 후, `0초`부터 `(play_time - adv_time - 1)초`까지 아래 반복
    1. 현재 광고 재생 시간부터 adv_time만큼의 구간의 누적 시청자 수를 구함 (`누적합` 이용)
    2. `최대 시청자 수`보다 `현재 시청자 수`가 작다면, 정답 및 최대 시청자 수 갱신
