### PR TITLE
220418) 1, 2, 3, 4번 문제

### DIFF
--- a/Wooyongjeong/220418/01 [BOJ] 22056 마법사 상어와 파이어볼.py
+++ b/Wooyongjeong/220418/01 [BOJ] 22056 마법사 상어와 파이어볼.py
@@ -1,0 +1,118 @@
+"""
+N x N 격자에 파이어볼 M개
+위치 (r, c), 질량 m, 방향 d, 속력 s
+
+방향은
+7 0 1
+6   2
+5 4 3
+
+1. 모든 파이어볼이 자신의 방향 d로 속력 s칸만큼 이동
+2. 이동이 끝나고 2개 이상의 파이어볼이 있는 칸에서는
+    1. 모든 파이어볼이 모두 하나로 합쳐짐
+    2. 파이어볼은 4개의 파이어볼로 나누어짐
+    3. ⌊(합쳐진 파이어볼 질량의 합)/5⌋     (내림임)
+    4. ⌊(합쳐진 파이어볼 속력의 합)/(합쳐진 파이어볼의 개수)⌋
+    5. if 방향이 모두 홀수 or 모두 짝수 -> 방향은 0, 2, 4, 6
+       else 방향 1, 3, 5, 7
+    6. 질량이 0인 파이어볼은 소멸됨
+"""
+import collections
+import math
+from typing import List, DefaultDict, Tuple
+
+
+class Fireball:
+    def __init__(self, m, s, d):
+        self.mass = m
+        self.speed = s
+        self.dir = d
+
+    def __str__(self):
+        return f"mass={self.mass}, speed={self.speed}, dir={self.dir}"
+
+
+def make_fireballs_info(data: List[int]) -> DefaultDict[Tuple, List[Fireball]]:
+    # 파이어볼의 위치를 key로, 파이어볼 객체를 value로 하는 dict를 만들어 반환하는 함수
+    info = collections.defaultdict(list)
+    for r, c, m, s, d in data:
+        info[(r - 1, c - 1)].append(Fireball(m, s, d))
+    return info
+
+
+def move_fireballs(info: DefaultDict[Tuple, List[Fireball]]) \
+        -> DefaultDict[Tuple, List[Fireball]]:
+    # 모든 파이어볼을 이동시키는 함수
+    new_info = collections.defaultdict(list)
+    for (x, y), fireballs in info.items():
+        for fireball in fireballs:
+            nx, ny = x, y
+            for _ in range(fireball.speed):
+                nx = (nx + dx[fireball.dir] + N) % N
+                ny = (ny + dy[fireball.dir] + N) % N
+            new_info[(nx, ny)].append(fireball)
+    return new_info
+
+
+def make_divided_fireballs(fireballs: List[Fireball]) -> List[Fireball]:
+    sum_mass, sum_speed, dir_mods = 0, 0, set()
+    for fireball in fireballs:
+        sum_mass += fireball.mass
+        sum_speed += fireball.speed
+        dir_mods.add(fireball.dir % 2)
+
+    mass = math.floor(sum_mass / 5)
+    if mass == 0:
+        return []
+    speed = math.floor(sum_speed / len(fireballs))
+    dirs = [0, 2, 4, 6] if len(dir_mods) < 2 else [1, 3, 5, 7]
+
+    divided_fireballs = []
+    for i in range(4):
+        divided_fireballs.append(Fireball(mass, speed, dirs[i]))
+    return divided_fireballs
+
+
+def merge_and_divide(info: DefaultDict[Tuple, List[Fireball]]) -> None:
+    # 같은 위치에 있는 파이어볼들을 합치고 나눈 후 질량이 0이면 소멸하는 함수
+    for (x, y), fireballs in info.items():
+        if len(fireballs) < 2:
+            # 2개 이상의 파이어볼이 있는 칸에 대해서만 합치고 나누기
+            continue
+
+        divided_fireballs = make_divided_fireballs(fireballs)
+        if not divided_fireballs:
+            # 질량이 0인 파이어볼은 소멸
+            info[(x, y)] = []
+            continue
+        info[(x, y)] = divided_fireballs
+
+
+def get_sum_of_mass(info: DefaultDict[Tuple, List[Fireball]]) -> int:
+    # 남아 있는 파이어볼 질량의 합을 구하는 함수
+    mass = 0
+    for fireballs in info.values():
+        for fireball in fireballs:
+            mass += fireball.mass
+    return mass
+
+
+def solution(k, data):
+    fireballs_info = make_fireballs_info(data)
+    for _ in range(k):
+        # 1. 모든 파이어볼 이동
+        fireballs_info = move_fireballs(fireballs_info)
+        # 2. 같은 위치에 있는 파이어볼들을 합치고 나눈 후 질량이 0이면 소멸
+        merge_and_divide(fireballs_info)
+    return get_sum_of_mass(fireballs_info)
+
+
+if __name__ == '__main__':
+    N, M, K = map(int, input().split())
+    data = [list(map(int, input().split())) for _ in range(M)]
+    # 7 0 1
+    # 6   2
+    # 5 4 3
+    dx = [-1, -1, 0, 1, 1, 1, 0, -1]
+    dy = [0, 1, 1, 1, 0, -1, -1, -1]
+    print(solution(K, data))

--- a/Wooyongjeong/220418/02 [BOJ] 16637 괄호 추가하기.py
+++ b/Wooyongjeong/220418/02 [BOJ] 16637 괄호 추가하기.py
@@ -1,0 +1,30 @@
+"""
+1. 괄호로 묶지 않고 바로 다음 숫자와 연산
+2. 괄호로 묶고 다음 숫자와 다다음 숫자를 연산한 결과와의 연산
+
+1번, 2번을 재귀함수로 풀면 될 듯
+
+수는 0~9, 연산자는 +,-,*
+"""
+
+
+def dfs(idx: int, value: int) -> None:
+    if idx >= N:
+        global ans
+        ans = max(ans, value)
+        return
+
+    operation = '+' if idx == 0 else exp[idx - 1]
+    if idx + 2 < N:
+        # 괄호로 묶기
+        dfs(idx + 4, eval(f"{value}{operation}({exp[idx: idx + 2 + 1]})"))
+    # 괄호로 묶지 않기
+    dfs(idx + 2, eval(f"{value}{operation}{exp[idx]}"))
+
+
+if __name__ == '__main__':
+    N = int(input())
+    exp = input()
+    ans = float('-inf')
+    dfs(0, 0)
+    print(ans)

--- a/Wooyongjeong/220418/03 [BOJ] 20166 문자열 지옥에 빠진 호석.py
+++ b/Wooyongjeong/220418/03 [BOJ] 20166 문자열 지옥에 빠진 호석.py
@@ -1,0 +1,45 @@
+import collections
+from typing import List, DefaultDict
+
+
+def find_every_possible_str(board: List[List[str]]) -> DefaultDict[str, int]:
+    """
+    board에서 찾을 수 있는 모든 길이가 1 이상 5 이하인 문자열의 개수를 세보는 함수
+    """
+    def dfs(x: int, y: int, now: str) -> None:
+        find[now] += 1
+
+        if len(now) == 5:
+            # 신이 좋아하는 문자열의 최대 길이는 5
+            return
+
+        for dx, dy in zip(dxs, dys):
+            # 격자가 환형으로 이어짐
+            nx = (x + dx + N) % N
+            ny = (y + dy + M) % M
+            dfs(nx, ny, now + board[nx][ny])
+
+    find = collections.defaultdict(int)  # {문자열: 개수}
+
+    for i in range(N):
+        for j in range(M):
+            # 모든 칸에서 시작해봄
+            dfs(i, j, board[i][j])
+
+    return find
+
+
+def solution(board: List[List[str]], strs: List[str]) -> None:
+    find = find_every_possible_str(board)
+
+    for s in strs:
+        print(find[s])
+
+
+if __name__ == '__main__':
+    N, M, K = map(int, input().split())
+    board = [list(input()) for _ in range(N)]
+    strs = [input() for _ in range(K)]
+    dxs = [1, 1, 1, 0, 0, -1, -1, -1]
+    dys = [1, 0, -1, 1, -1, 1, 0, -1]
+    solution(board, strs)

--- a/Wooyongjeong/220418/04 [PGS] 81303 표 편집.py
+++ b/Wooyongjeong/220418/04 [PGS] 81303 표 편집.py
@@ -1,0 +1,82 @@
+"""
+N이 100만
+
+배열을 사용하면.. 최악의 경우 U, D, C 명령이 O(N)만큼 걸림
+링크드 리스트 -> U, D는 움직이는 만큼 O(X)일거고, C 명령 O(1)만에 가능
+"""
+
+
+from typing import List, Dict
+
+
+def delete(cur: int, answer: List[str],
+           ll: Dict[int, List[int]], stack: List[List[str]]) -> int:
+    # 삭제
+    answer[cur] = 'X'
+    prev, next = ll[cur]
+    stack.append([prev, cur, next])
+
+    if prev == None:
+        # cur이 첫 행인 경우
+        ll[next][0] = None
+    elif next == None:
+        # cur이 마지막 행인 경우
+        ll[prev][1] = None
+    else:
+        ll[prev][1] = next
+        ll[next][0] = prev
+
+    # 지운 게 마지막 행이라면 바로 이전 행을 선택해야 함
+    # 아니라면 그 다음 행
+    return ll[cur][0] if next == None else ll[cur][1]
+
+
+def undo(answer: List[str],
+           ll: Dict[int, List[int]], stack: List[List[str]]) -> None:
+    # 되돌리기
+    prev, now, next = stack.pop()
+    answer[now] = 'O'
+
+    if next == None:
+        # 되돌릴 행이 마지막 행이었던 경우
+        ll[prev][1] = now
+    elif prev == None:
+        # 되돌릴 행이 첫 행이었던 경우
+        ll[next][0] = now
+    else:
+        ll[next][0] = now
+        ll[prev][1] = now
+
+
+def move(cur: int, c: List[str], ll: Dict[int, List[int]]) -> int:
+    # 위로 이동 or 아래로 이동
+    prev_or_next = 0 if c[0] == 'U' else 1
+    x = int(c[1])
+    for _ in range(x):
+        cur = ll[cur][prev_or_next]
+    return cur
+
+
+def solution(n: int, k: int, cmd: List[str]) -> str:
+    answer = ['O'] * n
+    # doubly linked-list를 dict로 표현
+    ll = {i: [i - 1, i + 1] for i in range(n)}
+    ll[0] = [None, 1]
+    ll[n - 1] = [n - 2, None]
+
+    cur = k  # 현재 위치
+    stack = []  # 'Z' 명령을 위한 스택
+
+    for c in cmd:
+        c = c.split()
+        if c[0] == 'C':
+            # 삭제
+            cur = delete(cur, answer, ll, stack)
+        elif c[0] == 'Z':
+            # 되돌리기
+            undo(answer, ll, stack)
+        else:
+            # 위 or 아래
+            cur = move(cur, c, ll)
+
+    return ''.join(answer)


### PR DESCRIPTION
# 01 [BOJ] 22056 마법사 상어와 파이어볼

* 구현, 시뮬레이션
* 모듈화 잘해서 문제대로 시뮬레이션하면 되는 문제
* 저번 주의 [낚시왕](https://www.acmicpc.net/problem/17143) 문제처럼 파이어볼의 위치를 key로, 해당 위치의 파이어볼 객체 리스트를 value로 하는 dict를 이용하여 해결했음

# 02 [BOJ] 16637 괄호 추가하기

* 재귀, 브루트포스
* 괄호로 묶지 않고 바로 다음 숫자와 연산하는 경우와 괄호로 묶고 다음 숫자와 다다음 숫자를 연산한 결과와 연산하는 경우를 모두 해보면 되는 문제
* N <= 19로 숫자는 최대 10개, 연산자는 최대 9개가 있을 수 있음. 숫자 개수를 M개라고 하면 O(logM)의 시간 복잡도로 낭낭하게 풀림

# 03 [BOJ] 20166 문자열 지옥에 빠진 호석

* 그래프 탐색(DFS), 해시를 사용한 집합과 맵
* 신이 좋아하는 문자열의 최대 길이가 5이고, 격자의 최대 크기는 10X10
    * 격자의 모든 위치에서 시작해서 4번의 이동, 매번 8방향 이동 가능이므로
    * 10*10*(8^4) = 409,600으로 낭낭함
* 나올 수 있는 모든 길이가 5 이하인 문자열에 대해 개수를 세서 걍 출력하면 됨.
* 문자열을 key로, 개수를 value로 하는 dict를 만들어서 해결

# 추가문제 [PGS] 81303 표 편집

* 구현
* 문제를 읽으보면 링크드 리스트를 사용하면 된다는 걸 바로 알 수 있음
    * 배열을 쓰면 C 명령이 최악의 경우 O(n)이 걸림. n이 최대 100만, cmd 개수가 최대 20만으로 효율성 테스트 통과 못함
* 링크드 리스트를 쓰면 C 명령 O(1)에 가능