### PR TITLE
220425) 1, 2, 3, 4번 문제

### DIFF
--- a/Wooyongjeong/220425/01 [BOJ] 17135 캐슬 디펜스.py
+++ b/Wooyongjeong/220425/01 [BOJ] 17135 캐슬 디펜스.py
@@ -1,0 +1,103 @@
+"""
+성에 궁수 3명을 놓아보는 최대 경우의 수는 15C3 = 455개
+
+castle_defense()에서
+1. 서순을 잘 짜자 (궁수의 사정거리에서 벗어났음에도 candidates에 넣고 있었음)
+2. candidates 중에서 궁수가 공격할 적을 선택할 때
+    - 가장 왼쪽만 고려했었음,,
+    - 사정거리가 되면 모두 candidates에 넣기 때문에 가장 가까운 적을 고려하지 못했음!
+"""
+import collections
+import copy
+from itertools import combinations
+from typing import Tuple, List, Dict
+
+
+def castle_defense(archers: Tuple, enemies: Dict[Tuple, bool]) -> int:
+    kill_cnt: int = 0
+
+    while enemies:
+        # 궁수들이 공격할 적을 선택
+        died = set()
+        for archer in archers:
+            enemy = find_enemy(archer, enemies)
+            if enemy == CANNOT_ATTACK:
+                continue
+            died.add(enemy)
+
+        # 선택된 적들을 죽임
+        for enemy in died:
+            del enemies[enemy]
+            kill_cnt += 1
+
+        # 적들이 이동
+        enemies = move_enemies(enemies)
+
+    return kill_cnt
+
+
+def find_enemy(archer: int, enemies: Dict[Tuple, bool]) -> Tuple[int, int]:
+    q = collections.deque()
+    visited = set()
+    q.append((N - 1, archer, 1))  # (x, y, d)
+    visited.add((N - 1, archer))
+
+    candidates = []
+    while q:
+        x, y, d = q.popleft()
+
+        if d > D:  # 궁수의 사정거리를 벗어나면 종료
+            break
+
+        if (x, y) in enemies:  # 공격할 수 있는 적 발견
+            candidates.append((x, y, d))
+            continue
+
+        for dx, dy in zip(dxs, dys):
+            nx, ny = x + dx, y + dy
+            if not in_range(nx, ny) or (nx, ny) in visited:
+                continue
+            q.append((nx, ny, d + 1))
+            visited.add((nx, ny))
+
+    # 가장 가깝고, 가장 왼쪽에 있는 적을 선택하기 위함
+    candidates.sort(key=lambda enemy: (enemy[2], enemy[1]))
+    if not candidates:
+        return CANNOT_ATTACK
+    return candidates[0][:2]
+
+
+def in_range(x: int, y: int) -> bool:
+    return 0 <= x < N and 0 <= y < M
+
+
+def move_enemies(enemies: Dict[Tuple, bool]) -> Dict[Tuple, bool]:
+    new_enemies = {}
+    for (x, y) in enemies:
+        if x == N - 1:  # 성이 있는 칸으로 이동한 경우
+            continue
+        new_enemies[(x + 1, y)] = True
+    return new_enemies
+
+
+def solution(enemies: Dict[Tuple, bool]) -> int:
+    answer: int = 0
+    for archers in combinations(range(M), ARCHER_SIZE):
+        copied_enemies = copy.deepcopy(enemies)
+        answer = max(answer, castle_defense(archers, copied_enemies))
+    return answer
+
+
+if __name__ == '__main__':
+    ARCHER_SIZE = 3
+    CANNOT_ATTACK = (-1, -1)
+    dxs = [0, -1, 0]  # ←, ↑, →
+    dys = [-1, 0, 1]
+    N, M, D = map(int, input().split())
+    enemies = {}
+    for i in range(N):
+        tmp = list(map(int, input().split()))
+        for j in range(M):
+            if tmp[j] == 1:
+                enemies[(i, j)] = True
+    print(solution(enemies))

--- a/Wooyongjeong/220425/01 [BOJ] 17135 캐슬 디펜스.py
+++ b/Wooyongjeong/220425/01 [BOJ] 17135 캐슬 디펜스.py
@@ -4,16 +4,15 @@
 castle_defense()에서
 1. 서순을 잘 짜자 (궁수의 사정거리에서 벗어났음에도 candidates에 넣고 있었음)
 2. candidates 중에서 궁수가 공격할 적을 선택할 때
-    - 가장 왼쪽만 고려했었음,,
+    - 사정거리도 고려했어야 됐는데 빼먹고 가장 왼쪽만 고려했었음,,
     - 사정거리가 되면 모두 candidates에 넣기 때문에 가장 가까운 적을 고려하지 못했음!
 """
 import collections
 import copy
 from itertools import combinations
-from typing import Tuple, List, Dict
 
 
-def castle_defense(archers: Tuple, enemies: Dict[Tuple, bool]) -> int:
+def castle_defense(archers: tuple, enemies: dict[tuple, bool]) -> int:
     kill_cnt: int = 0
 
     while enemies:
@@ -36,7 +35,7 @@ def castle_defense(archers: Tuple, enemies: Dict[Tuple, bool]) -> int:
     return kill_cnt
 
 
-def find_enemy(archer: int, enemies: Dict[Tuple, bool]) -> Tuple[int, int]:
+def find_enemy(archer: int, enemies: dict[tuple, bool]) -> tuple[int, int]:
     q = collections.deque()
     visited = set()
     q.append((N - 1, archer, 1))  # (x, y, d)
@@ -71,7 +70,7 @@ def in_range(x: int, y: int) -> bool:
     return 0 <= x < N and 0 <= y < M
 
 
-def move_enemies(enemies: Dict[Tuple, bool]) -> Dict[Tuple, bool]:
+def move_enemies(enemies: dict[tuple, bool]) -> dict[tuple, bool]:
     new_enemies = {}
     for (x, y) in enemies:
         if x == N - 1:  # 성이 있는 칸으로 이동한 경우
@@ -80,7 +79,7 @@ def move_enemies(enemies: Dict[Tuple, bool]) -> Dict[Tuple, bool]:
     return new_enemies
 
 
-def solution(enemies: Dict[Tuple, bool]) -> int:
+def solution(enemies: dict[tuple, bool]) -> int:
     answer: int = 0
     for archers in combinations(range(M), ARCHER_SIZE):
         copied_enemies = copy.deepcopy(enemies)

--- a/Wooyongjeong/220425/02 [BOJ] 17136 색종이 붙이기.py
+++ b/Wooyongjeong/220425/02 [BOJ] 17136 색종이 붙이기.py
@@ -1,0 +1,70 @@
+"""
+반복문을 돌다 1을 만나면
+-> 5x5, 4x4, ..., 1x1 순으로 확인하여 붙일 수 있는 건 붙이고 넘어가는 방식으로 백트래킹
+"""
+from enum import Enum
+
+
+class Paper(Enum):
+    ATTACH = 0
+    DETACH = 1
+    SIZE = 10
+
+
+def in_range(x: int, y: int) -> bool:
+    return 0 <= x < Paper.SIZE.value and 0 <= y < Paper.SIZE.value
+
+
+def check(x: int, y: int, size: int) -> bool:
+    for i in range(x, x + size):
+        for j in range(y, y + size):
+            if not in_range(i, j) or board[i][j] != 1:
+                return False
+    return True
+
+
+def papering(x: int, y: int, size: int, flag: int) -> None:
+    for i in range(x, x + size):
+        for j in range(y, y + size):
+            board[i][j] = flag
+
+
+def dfs(x: int, y: int, cnt: int) -> None:
+    global ans
+
+    if x >= Paper.SIZE.value - 1 and y > Paper.SIZE.value - 1:
+        ans = min(ans, cnt)
+        return
+
+    if ans <= cnt:
+        return
+
+    if y >= Paper.SIZE.value:
+        dfs(x + 1, 0, cnt)
+        return
+
+    if board[x][y] == 1:
+        for size in range(5, 0, -1):
+            if paper[size] > 0 and check(x, y, size):
+                # 색종이 붙여보기
+                papering(x, y, size, Paper.ATTACH.value)
+                paper[size] -= 1
+                # 다음으로
+                dfs(x, y + 1, cnt + 1)
+                # 색종이 떼기
+                papering(x, y, size, Paper.DETACH.value)
+                paper[size] += 1
+    else:
+        dfs(x, y + 1, cnt)
+
+
+if __name__ == '__main__':
+    INF = int(1e9)
+    board = [
+        list(map(int, input().split()))
+        for _ in range(Paper.SIZE.value)
+    ]
+    paper = {i: 5 for i in range(1, 6)}
+    ans = INF
+    dfs(0, 0, 0)
+    print(ans if ans != INF else -1)

--- a/Wooyongjeong/220425/02 [BOJ] 17136 색종이 붙이기.py
+++ b/Wooyongjeong/220425/02 [BOJ] 17136 색종이 붙이기.py
@@ -2,17 +2,10 @@
 반복문을 돌다 1을 만나면
 -> 5x5, 4x4, ..., 1x1 순으로 확인하여 붙일 수 있는 건 붙이고 넘어가는 방식으로 백트래킹
 """
-from enum import Enum
-
-
-class Paper(Enum):
-    ATTACH = 0
-    DETACH = 1
-    SIZE = 10
 
 
 def in_range(x: int, y: int) -> bool:
-    return 0 <= x < Paper.SIZE.value and 0 <= y < Paper.SIZE.value
+    return 0 <= x < SIZE and 0 <= y < SIZE
 
 
 def check(x: int, y: int, size: int) -> bool:
@@ -32,14 +25,14 @@ def papering(x: int, y: int, size: int, flag: int) -> None:
 def dfs(x: int, y: int, cnt: int) -> None:
     global ans
 
-    if x >= Paper.SIZE.value - 1 and y > Paper.SIZE.value - 1:
-        ans = min(ans, cnt)
-        return
-
     if ans <= cnt:
         return
 
-    if y >= Paper.SIZE.value:
+    if x >= SIZE - 1 and y > SIZE - 1:
+        ans = min(ans, cnt)
+        return
+
+    if y >= SIZE:
         dfs(x + 1, 0, cnt)
         return
 
@@ -47,22 +40,25 @@ def dfs(x: int, y: int, cnt: int) -> None:
         for size in range(5, 0, -1):
             if paper[size] > 0 and check(x, y, size):
                 # 색종이 붙여보기
-                papering(x, y, size, Paper.ATTACH.value)
+                papering(x, y, size, ATTACH)
                 paper[size] -= 1
                 # 다음으로
                 dfs(x, y + 1, cnt + 1)
                 # 색종이 떼기
-                papering(x, y, size, Paper.DETACH.value)
+                papering(x, y, size, DETACH)
                 paper[size] += 1
     else:
         dfs(x, y + 1, cnt)
 
 
 if __name__ == '__main__':
+    ATTACH = 0
+    DETACH = 1
+    SIZE = 10
     INF = int(1e9)
     board = [
         list(map(int, input().split()))
-        for _ in range(Paper.SIZE.value)
+        for _ in range(SIZE)
     ]
     paper = {i: 5 for i in range(1, 6)}
     ans = INF

--- a/Wooyongjeong/220425/03 [BOJ] 1826 연료 채우기.py
+++ b/Wooyongjeong/220425/03 [BOJ] 1826 연료 채우기.py
@@ -1,0 +1,46 @@
+"""
+주유소 개수 N <= 1만
+백트래킹은 당연히 안됨
+
+주유소에 멈추는 횟수를 최소화 하고 싶다
+-> 갈 수 있는 주유소 중 기름을 가장 많이 넣을 수 있는 주유소에서 멈춘다?
+-> heapq 이용해서 정렬
+"""
+import heapq
+
+
+def solution(fuel_left: int, dest: int, gas_station: list[list[int]]) -> int:
+    """
+    data는 (주유소 까지의 거리, 연료 양) 기준으로 min heap
+    """
+    answer = 0
+    heap = []
+
+    while fuel_left < dest:
+        # 아직 주유소가 남아 있고, 남은 연료로 해당 주유소까지 갈 수 있을 때까지 반복
+        while gas_station and gas_station[0][0] <= fuel_left:
+            dist, fuel_amount = heapq.heappop(gas_station)
+            # 주유할 수 있는 연료 양 기준으로 max heap 만듬
+            heapq.heappush(heap, (-fuel_amount, dist))
+
+        if not heap:
+            # 현재 남아 있는 연료로 주유소까지 갈 수 없다 == 마을까지도 못 간다
+            return -1
+
+        # 가장 많은 기름을 넣을 수 있는 주유소에서 멈춤
+        fuel_amount, dist = heapq.heappop(heap)
+        fuel_amount *= -1
+
+        fuel_left += fuel_amount
+        answer += 1
+
+    return answer
+
+
+if __name__ == '__main__':
+    N = int(input())
+    data = []
+    for _ in range(N):
+        heapq.heappush(data, list(map(int, input().split())))
+    L, P = map(int, input().split())
+    print(solution(P, L, data))

--- a/Wooyongjeong/220425/03 [BOJ] 1826 연료 채우기.py
+++ b/Wooyongjeong/220425/03 [BOJ] 1826 연료 채우기.py
@@ -4,19 +4,21 @@
 
 주유소에 멈추는 횟수를 최소화 하고 싶다
 -> 갈 수 있는 주유소 중 기름을 가장 많이 넣을 수 있는 주유소에서 멈춘다?
--> heapq 이용해서 정렬
+-> heapq 이용해서 그리디
 """
 import heapq
 
 
-def solution(fuel_left: int, dest: int, gas_station: list[list[int]]) -> int:
+def solution(village_dist: int, fuel_left: int, gas_station: list[list[int]]) -> int:
     """
-    data는 (주유소 까지의 거리, 연료 양) 기준으로 min heap
+    마을까지 거리 village_dist
+    남은 연료 양 fuel_left
+    gas_station은 (주유소 까지의 거리, 연료 양) 기준으로 min heap
     """
     answer = 0
     heap = []
 
-    while fuel_left < dest:
+    while fuel_left < village_dist:
         # 아직 주유소가 남아 있고, 남은 연료로 해당 주유소까지 갈 수 있을 때까지 반복
         while gas_station and gas_station[0][0] <= fuel_left:
             dist, fuel_amount = heapq.heappop(gas_station)
@@ -43,4 +45,4 @@ if __name__ == '__main__':
     for _ in range(N):
         heapq.heappush(data, list(map(int, input().split())))
     L, P = map(int, input().split())
-    print(solution(P, L, data))
+    print(solution(L, P, data))

--- a/Wooyongjeong/220425/04 [PGS] 67258 보석 쇼핑.py
+++ b/Wooyongjeong/220425/04 [PGS] 67258 보석 쇼핑.py
@@ -1,0 +1,45 @@
+"""
+N <= 10만으로, O(N^2)으로는 안됨
+투 포인터 써서 O(N)으로
+"""
+import collections
+
+
+def solution(gems):
+    answer = []
+
+    shortest = len(gems) + 1
+    start, end = 0, 0
+
+    all_kind = len(set(gems))
+    gems_dict = collections.defaultdict(int)
+
+    while end < len(gems):
+        gems_dict[gems[end]] += 1
+        end += 1
+
+        if len(gems_dict) == all_kind:
+            while start < end:
+                if gems_dict[gems[start]] > 1:
+                    gems_dict[gems[start]] -= 1
+                    start += 1
+                elif shortest > end - start:
+                    shortest = end - start
+                    answer = [start + 1, end]
+                    break
+                else:
+                    break
+
+    return answer
+
+
+if __name__ == '__main__':
+    gems_list = [
+        ["DIA", "RUBY", "RUBY", "DIA", "DIA", "EMERALD", "SAPPHIRE", "DIA"],
+        ["AA", "AB", "AC", "AA", "AC"],
+        ["XYZ", "XYZ", "XYZ"],
+        ["ZZZ", "YYY", "NNNN", "YYY", "BBB"]
+    ]
+
+    for gems in gems_list:
+        print(solution(gems))


### PR DESCRIPTION
# 01 [BOJ] 17135 캐슬 디펜스

* 구현, 시뮬레이션
* 궁수 3명이 서 있을 자리를 고르고 (nC3) 시뮬레이션 해보면 되는 문제.
    * `N <= 15`라 `15C3 = 455`, `15^2 = 225`로 시간 제한 매우 낭낭
* 궁수는 적을 공격할 때 사정거리 제한인 D 이하에 있는 적들 중 가장 가까이에 있으면서 가장 왼쪽에 있는 적을 고르는 게 뽀인트.
    * 거기에 여러 궁수가 같은 적을 고를 수도 있는 것까지 고려해야했음

# 02 [BOJ] 17136 색종이 붙이기

* 브루트포스, 백트래킹
* 종이를 표현한 2차원 배열을 순회하며 1을 발견하면 5x5, 4x4, ... , 1x1 색종이를 붙여가며 가능하다면 덮어보고 넘어가는 백트래킹 + 브루트포스 알고리즘으로 해결
* 최적화를 약간 해줘야 시간 초과가 안남

# 03 [BOJ] 1826 연료 채우기

* 그리디, 우선순위 큐
* 주유소 개수 `N <= 10,000`으로, 모든 주유소에 멈춰보는 식으로 백트래킹을 하면... 무조건 시간 초과
* 주유소에 멈추는 횟수를 최소화 => 매 번 남아 있는 기름으로 갈 수 있는 주유소 중 가장 기름을 많이 넣고 출발할 수 있는(=`이번 주유로 최대한 멀리 갈 수 있도록 해주는`) 주유소를 선택하면서 가는 그리디 알고리즘으로 해결
    * 주유소를 선택할 때마다 이번 주유소에서 넣은 기름으로 최대한 멀리 갈 수 있도록 선택하기 때문에, 그리디로 최적해를 찾을 수 있음
    * 이 알고리즘으로 중간에 더 이상 갈 수 있는 주유소가 없다 -> 매 번 최대한 멀리 갈 수 있게 고려하면서 왔기 때문에 마을에는 당연히 도착하지 못함 
* `우선순위 큐`를 이용해 그리디 알고리즘을 구현하여 해결했음
    * 우선순위 큐를 이용하면 `O(NlogN)`으로 해결 가능
* 입력으로 주어지는 주유소 정보를 `min_heap`으로 저장했음
    * `(주유소까지의 거리), (넣을 수 있는 연료 양)` 순으로 정렬되도록
    * 그래서 매번 탐색할 때마다 가까운 주유소순으로 볼 수 있음
    * ```python
      heapq.heappush(data, (dist, fuel))
      ```
* 우선순위큐를 하나 더 썼음
    * 주유소를 선택할 때마다, 현재 위치에서 그 주유소로 갈 수 있을 때까지 `heapq.heappop(data)`으로 빼서 저장했음
    * `-(넣을 수 있는 연료 양), (주유소까지의 거리)` 순으로다가 정렬되도록
    * 그래서 현재 위치에서 남은 연료로 갈 수 있는 주유소들 중에서 `가장 많은 기름을 넣을 수 있는 주유소`가 선택되도록 했음
    * ```python
      heapq.heappush(heap, (-fuel, dist))
      ```

# 04 [PGS] 67258 보석 쇼핑

* 투 포인터
* N <= 10만. N^2 = 100억.. 완탐으로는 시간 초과
* 문제를 읽어보면.. 투 포인터 써서 보석 종류 세면서 풀면 O(N)으로 풀 수 있음
* start, end 두 포인터를 모두 0번 인덱스부터 시작 -> end 하나씩 늘려가면서
    * [start, end]에서 진열된 모든 종류의 보석을 포함하면 start도 하나씩 늘려가면서 확인하는 식으로 깔끔하게 해결
